### PR TITLE
Prefetch prices after loading tabs

### DIFF
--- a/components/mainFrame/mainFramePresenter.tsx
+++ b/components/mainFrame/mainFramePresenter.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { ReactNode } from 'react';
 import { useLoadCompanyTabs } from '../../controllers/data/hooks';
+import { usePrefetchPricesTabs } from '../../controllers/net/price';
 import logoSrc from '../../public/assets/images/junekim_192x192.png';
 import styles from './mainFrame.module.scss';
 import Menu from './mainFrameViewMenu';
@@ -9,6 +10,7 @@ import Navbar from './mainFrameViewNavbar';
 const Presenter = (props: { children?: ReactNode[] | ReactNode }) => {
   const { children } = props;
   useLoadCompanyTabs();
+  usePrefetchPricesTabs();
   const year = new Date().getFullYear();
 
   return (

--- a/controllers/net/price.ts
+++ b/controllers/net/price.ts
@@ -1,5 +1,8 @@
-import { QueryFunctionContext, useQuery } from '@tanstack/react-query';
+import { QueryFunctionContext, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 import { PRICES_URL } from '../apiURLs';
+import { StateCompanyTabs } from '../data/states';
 import {
   TypeError,
   TypeIDWeek,
@@ -22,6 +25,23 @@ export const useGetPrices = (req: TypePriceRequest) => {
     staleTime: Infinity,
     placeholderData: [],
   });
+};
+
+export const usePrefetchPricesTabs = () => {
+  const tabs = useRecoilValue(StateCompanyTabs);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    for (const tab of tabs) {
+      const code = tab.company.srtnCd;
+      const type = tab.mainType;
+      queryClient.prefetchQuery({
+        queryKey: ['prices', code, type],
+        queryFn: getPrices,
+        staleTime: Infinity,
+      });
+    }
+  }, [tabs, queryClient]);
 };
 
 export const useGetPricesLatest = (req: TypePriceRequest) => {


### PR DESCRIPTION
# Reason
1. This decreases waiting time significantly when a user clicks a tab to see a chart while it might result in unnecessary data transfer from network upfront.
2. However, for users typically check out charts of all companies on nav, it is worth prefetching all of their data upfront

# Preformance
- **Waiting time** decreases **from 1s - 2s to 0.1s - 0.2s** on typical Korean internet environment.
- **10x faster** than before optimization